### PR TITLE
Fix CMake build on Raspberry Pi / Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,14 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
-set(OpenCV_DIR "D:/opencv/build/x64/vc16/lib")
-set(Qt6_DIR "D:/Qt/6.10.0/msvc2022_64/lib/cmake/Qt6")
+if(WIN32)
+    if(NOT DEFINED CACHE{OpenCV_DIR})
+        set(OpenCV_DIR "D:/opencv/build/x64/vc16/lib" CACHE PATH "OpenCV build directory")
+    endif()
+    if(NOT DEFINED CACHE{Qt6_DIR})
+        set(Qt6_DIR "D:/Qt/6.10.0/msvc2022_64/lib/cmake/Qt6" CACHE PATH "Qt6 cmake directory")
+    endif()
+endif()
 
 find_package(OpenCV REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS


### PR DESCRIPTION
The hardcoded Windows defaults for OpenCV_DIR and Qt6_DIR prevented find_package from using system-installed Qt6 and OpenCV on Linux, breaking the build on Raspberry Pi OS. Guard those defaults with WIN32 and only apply them when the user has not already overridden them via the cache, so Linux builds pick up packages from apt.

https://claude.ai/code/session_01MD8fr7ovZzQVQspcC1mATQ